### PR TITLE
add support for Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,20 @@
 
 Important additions/changes/removals will appear here.
 
+## v2.3.0 (April 17, 2023)
+
+### Changed
+* A `Drip` now accepts an `action_class` option, in addition to the previous options
+
+### Added
+* Ability to use normal Ruby classes, not just ActionMailer
+
 ## v2.2.0 (March 20, 2023)
 
 ### Fixed
-* Documentation about `rescue_from` in a `Dripper`. 
+* Documentation about `rescue_from` in a `Dripper` 
 
 ### Added
-
 * Ability to add new mailings to a campaign using `CampaignSubscription#refuel!`
     
     - Someone had mentioned that:
@@ -24,7 +31,6 @@ Important additions/changes/removals will appear here.
 * Ruby 3 bug 
 
 ### Added
-
 * Support for rescuing from an error during delivery:
 
     ```

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    caffeinate (2.2.0)
+    caffeinate (2.3.0)
       rails (>= 5.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@
 
 # Caffeinate
 
-Caffeinate is a drip engine for managing, creating, and sending scheduled messages sequences from your Ruby on Rails application. This was originally meant for email, but now supports anything!
+Caffeinate is a drip engine for managing, creating, and performing scheduled messages sequences from your Ruby on Rails application. This was originally meant for email, but now supports anything!
 
-Caffeinate provides a simple DSL to create scheduled sequences which can be used by ActionMailer, or any Ruby object, without any additional configuration. 
+Caffeinate provides a simple DSL to create scheduled sequences which can be sent by ActionMailer, or invoked by a Ruby object, without any additional configuration. 
 
 There's a cool demo app you can spin up [here](https://github.com/joshmn/caffeinate-marketing).
 
 ## Now supports POROs!
 
-Originally, this was meant for just email, but now supports plain old Ruby objects just as well. Having said, the documentation primarily revolves around using ActionMailer, but it's just as easy to plug in a PORO. See `Using Without ActionMailer` below.
+Originally, this was meant for just email, but as of V2.3 supports plain old Ruby objects just as well. Having said, the documentation primarily revolves around using ActionMailer, but it's just as easy to plug in any Ruby class. See `Using Without ActionMailer` below.
 
 ## Is this thing dead?
 
@@ -242,6 +242,7 @@ Now supports POROs <sup>that inherit from a magical class</sup>! Using the examp
 
 Caffeinate also...
 
+* ✅ Works with regular Ruby methods as of V2.3
 * ✅ Allows hyper-precise scheduled times. 9:19AM _in the user's timezone_? Sure! **Only on business days**? YES! 
 * ✅ Periodicals
 * ✅ Manages unsubscribes

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ class User
     send_twilio_message("Welcome to our app!")
   end
 
-  def some_cool_tips(user)
+  def some_cool_tips
     return if self.unsubscribed_from_onboarding_campaign?
 
     send_twilio_message("Here are some cool tips for MyCoolApp")

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ end
 
 ```ruby
 class OnboardingWorker
-  include SidekiqWorker
+  include Sidekiq::Worker
   
   def perform(action, user_id)
     user = User.find(user_id)

--- a/docs/6-without-action-mailer.md
+++ b/docs/6-without-action-mailer.md
@@ -145,3 +145,44 @@ end
 Done! Everything is handled the same as it would be otherwise. Caffeinate will still mark them as sent after this action completes successfully.
 
 If you need to bail, raise an error.
+
+## Using the actions as setup
+
+If you return an object that implements `#deliver!`, it will be called. Here's an example:
+
+```ruby
+class PostAPIDeliver
+  def initialize(to:, content:)
+    @to = to 
+    @content = content 
+  end
+  
+  def deliver!(_action)
+    HTTParty.post # ...
+  end
+end
+
+class OnboardingAction < ActionMailer::Base
+  def welcome_to_my_cool_app(mailing)
+    @user = mailing.subscriber
+    post_to_api(to: @user.phone_number, content: "Welcome to CoolApp!")
+  end
+
+  def some_cool_tips(mailing)
+    @user = mailing.subscriber
+    post_to_api(to: @user.phone_number, content: "Here are some cool tips for MyCoolApp")
+  end
+
+  def help_getting_started(mailing)
+    @user = mailing.subscriber
+    post_to_api(to: @user.phone_number, content: "Do you need help getting started?")
+  end
+  
+  private 
+  
+  def post_to_api(to:, content:)
+    PostAPIDeliver.new(to: to, content: content)
+  end
+end
+```
+

--- a/docs/6-without-action-mailer.md
+++ b/docs/6-without-action-mailer.md
@@ -1,0 +1,147 @@
+# Without ActionMailer
+
+As of Caffeinate v2.3.0, you can use Caffeinate without ActionMailer! Internally, these are called "Actions". Here's how to transition from an ActionMailer-based Drip to an Action-based Drip.
+
+## Example using ActionMailer
+
+Here's a normal Dripper:
+
+```ruby
+class OnboardingDripper < ApplicationDripper
+  self.campaign = :onboarding 
+  
+  before_drip do |_drip, mailing| 
+    if mailing.subscription.subscriber.onboarding_completed?
+      mailing.subscription.unsubscribe!("Completed onboarding")
+      throw(:abort)
+    end 
+  end
+  
+  # map drips to the mailer
+  drip :welcome_to_my_cool_app, mailer: 'OnboardingMailer', delay: 0.hours
+  drip :some_cool_tips, mailer: 'OnboardingMailer', delay: 2.days
+  drip :help_getting_started, mailer: 'OnboardingMailer', delay: 3.days
+end
+```
+
+With corresponding `OnboardingMailer`:
+
+```ruby
+class OnboardingMailer < ActionMailer::Base
+  def welcome_to_my_cool_app(mailing)
+    @user = mailing.subscriber
+    mail(to: @user.email, subject: "Welcome to CoolApp!")
+  end
+
+  def some_cool_tips(mailing)
+    @user = mailing.subscriber
+    mail(to: @user.email, subject: "Here are some cool tips for MyCoolApp")
+  end
+
+  def help_getting_started(mailing)
+    @user = mailing.subscriber
+    mail(to: @user.email, subject: "Do you need help getting started?")
+  end
+end
+```
+
+To change our drips to a PORO-handled object, we need to:
+
+1. Change each `drip` option `mailer` to `action_class` in `OnboardingDripper` to `OnboardingAction`
+2. Rename `OnboardingMailer` to `OnboardingAction`
+3. Have `OnboardingAction` inherit from `Caffeinate::Action`
+4. Do something other than `mail`
+
+### 1. Change drip option
+
+```ruby
+class OnboardingDripper < ApplicationDripper
+  self.campaign = :onboarding 
+  
+  before_drip do |_drip, mailing| 
+    if mailing.subscription.subscriber.onboarding_completed?
+      mailing.subscription.unsubscribe!("Completed onboarding")
+      throw(:abort)
+    end 
+  end
+  
+  # map drips to the mailer
+  drip :welcome_to_my_cool_app, action_class: 'OnboardingAction', delay: 0.hours
+  drip :some_cool_tips, action_class: 'OnboardingAction', delay: 2.days
+  drip :help_getting_started, action_class: 'OnboardingAction', delay: 3.days
+end
+```
+
+### 2. Rename OnboardingMailer
+
+```ruby
+
+class OnboardingAction < ActionMailer::Base
+  def welcome_to_my_cool_app(mailing)
+    @user = mailing.subscriber
+    mail(to: @user.email, subject: "Welcome to CoolApp!")
+  end
+
+  def some_cool_tips(mailing)
+    @user = mailing.subscriber
+    mail(to: @user.email, subject: "Here are some cool tips for MyCoolApp")
+  end
+
+  def help_getting_started(mailing)
+    @user = mailing.subscriber
+    mail(to: @user.email, subject: "Do you need help getting started?")
+  end
+end
+```
+
+### 3. Change subclass
+
+```ruby
+class OnboardingMailer < Caffeinate::Action
+  def welcome_to_my_cool_app(mailing)
+    @user = mailing.subscriber
+    mail(to: @user.email, subject: "Welcome to CoolApp!")
+  end
+
+  def some_cool_tips(mailing)
+    @user = mailing.subscriber
+    mail(to: @user.email, subject: "Here are some cool tips for MyCoolApp")
+  end
+
+  def help_getting_started(mailing)
+    @user = mailing.subscriber
+    mail(to: @user.email, subject: "Do you need help getting started?")
+  end
+end
+```
+
+### 4. Do something different than `mail`
+
+```ruby
+class OnboardingAction < ActionMailer::Base
+  def welcome_to_my_cool_app(mailing)
+    @user = mailing.subscriber
+    post_to_api(to: @user.phone_number, content: "Welcome to CoolApp!")
+  end
+
+  def some_cool_tips(mailing)
+    @user = mailing.subscriber
+    post_to_api(to: @user.phone_number, content: "Here are some cool tips for MyCoolApp")
+  end
+
+  def help_getting_started(mailing)
+    @user = mailing.subscriber
+    post_to_api(to: @user.phone_number, content: "Do you need help getting started?")
+  end
+  
+  private 
+  
+  def post_to_api(to:, content:)
+    HTTParty.post # ... 
+  end
+end
+```
+
+Done! Everything is handled the same as it would be otherwise. Caffeinate will still mark them as sent after this action completes successfully.
+
+If you need to bail, raise an error.

--- a/docs/7-actions.md
+++ b/docs/7-actions.md
@@ -1,0 +1,130 @@
+# Actions
+
+Actions allow you to integrate Caffeinate's timing logic with non-ActionMailer classes and methods.
+
+## Compatability
+
+* ✅ callbacks
+* ✅ periodicals
+* ❌ async delivery 
+
+## Usage
+
+We'll pretend that we have a custom SMS class that looks like this:
+
+```ruby
+class SMS
+  attr_accessor :to, :body
+  
+  def send! 
+    response = HTTParty.post("some-endpoint", body: { to: to, body: body}.to_json)
+    raise HTTParty::ResponseError unless response.success? 
+    
+    true 
+  end
+end
+```
+
+### 1. Create a Dripper 
+
+```ruby
+class UserDripper < ApplicationDripper
+  self.campaign = :user 
+  
+  drip :welcome, action_class: "UserAction", in: 5.minutes 
+  drip :hows_it_going, action_class: "UserAction", in: 3.days 
+  drip :upsell, action_class: "UserAction", in: 7.days 
+end
+```
+
+Note here that we're using `action_class` instead of `mailer_class`. Everything else is the same, though.
+
+### 2. Create a `Caffeinate::Action`
+
+This is a special class that acts similarly to `ActionMailer::Base`. 
+
+```ruby
+class UserAction < Caffeinate::Action
+  def welcome(mailing)
+    user = mailing.subscriber
+
+    message = SMS.new.tap do |sms|
+      sms.to = user.phone_number
+      sms.body = "Welcome to our app!"
+    end
+
+    message.send!
+  end
+
+  def hows_it_going(mailing)
+    user = mailing.subscriber
+
+    message = SMS.new.tap do |sms|
+      sms.to = user.phone_number
+      sms.body = "hey it's your account manager how's it going?!"
+    end
+
+    message.send!
+  end
+  
+  def upsell(mailing)
+    user = mailing.subscriber
+
+    message = SMS.new.tap do |sms|
+      sms.to = user.phone_number
+      sms.body = "hey it's your account manager we're running out of money so can you change plans to make the investors happy?!"
+    end
+
+    message.send!
+  end
+end
+```
+
+And you're done! This will operate as Caffeinate normally does.
+
+## Some special cases
+
+### Using the methods for setup instead of outright-sending
+
+You can use the method (`welcome`, `hows_it_going`, and `upsell`) to setup an object for delivery, which is ultimately executed by Caffeinate.
+
+To do this, return an object that responds to `deliver!` in the method. This method must take an argument, which will be the instantiated `Action` object. This object will have two methods available that may be convenient to you: `action_name` and `caffeinate_mailing`.
+
+`#deliver!` will be called immediately prior to marking the `Caffeinate::Mailing` as sent. If this raises an error, it will not be marked as sent.
+
+Here's an example:
+
+```ruby
+class UserAction < Caffeinate::Action
+  class Envelope
+    def initialize(user)
+      @sms = SMS.new
+      @sms.to = user.phone_number 
+    end
+    
+    def deliver!(action)
+      # action will expose `#caffeinate_mailing` and `#action_name`
+      @sms.body = # ... 
+      @sms.send! 
+    end
+  end
+  
+  def welcome(mailing)
+    user = mailing.subscriber
+
+    Envelope.new(user)
+  end
+
+  def hows_it_going(mailing)
+    user = mailing.subscriber
+    
+    Envelope.new(user)
+  end
+  
+  def upsell(mailing)
+    user = mailing.subscriber
+    
+    Envelope.new(user)
+  end
+end
+```

--- a/lib/caffeinate.rb
+++ b/lib/caffeinate.rb
@@ -14,6 +14,7 @@ end
 require 'caffeinate/mail_ext'
 require 'caffeinate/engine'
 require 'caffeinate/drip'
+require 'caffeinate/action'
 require 'caffeinate/url_helpers'
 require 'caffeinate/configuration'
 require 'caffeinate/dripper/base'

--- a/lib/caffeinate/action.rb
+++ b/lib/caffeinate/action.rb
@@ -18,6 +18,7 @@ module Caffeinate
   class Action
     attr_accessor :caffeinate_mailing
     attr_accessor :perform_deliveries
+    attr_reader :action_name
 
     class DeliveryMethod
       def deliver!(action)

--- a/lib/caffeinate/action.rb
+++ b/lib/caffeinate/action.rb
@@ -100,6 +100,22 @@ module Caffeinate
       self
     end
 
+    # This method bypasses checking perform_deliveries and raise_delivery_errors,
+    # so use with caution.
+    #
+    # It still however fires off the interceptors and calls the observers callbacks if they are defined.
+    #
+    # Returns self
+    def deliver!
+      inform_interceptors
+      handled = send(@action_name, caffeinate_mailing)
+      if handled.respond_to?(:deliver!) && !handled.is_a?(Caffeinate::Mailing)
+        handled.deliver!(self)
+      end
+      inform_observers
+      self
+    end
+
     private
 
     def inform_interceptors

--- a/lib/caffeinate/action.rb
+++ b/lib/caffeinate/action.rb
@@ -1,0 +1,68 @@
+require 'caffeinate/message_handler'
+
+module Caffeinate
+  # Allows you to use a PORO for a drip; acts just like ActionMailer::Base
+  #
+  # Usage:
+  #   class TextHandler < Caffeinate::Action
+  #     def welcome(mailing)
+  #       user = mailing.subscriber
+  #       HTTParty.post("...") # ...
+  #     end
+  #   end
+  #
+  # In the future (when?), "mailing" objects will become "messages".
+  class Action
+    attr_accessor :caffeinate_mailing
+    attr_accessor :perform_deliveries
+
+    class << self
+      def action_methods
+        @action_methods ||= begin
+                              methods = (public_instance_methods(true) -
+                                internal_methods +
+                                public_instance_methods(false))
+                              methods.map!(&:to_s)
+                              methods.to_set
+                            end
+      end
+
+      def internal_methods
+        controller = self
+
+        controller = controller.superclass until controller.abstract?
+        controller.public_instance_methods(true)
+      end
+
+      def method_missing(method_name, *args)
+        if action_methods.include?(method_name.to_s)
+          ::Caffeinate::MessageHandler.new(self, method_name, *args)
+        else
+          super
+        end
+      end
+      ruby2_keywords(:method_missing)
+
+      def respond_to_missing?(method, include_all = false)
+        action_methods.include?(method.to_s) || super
+      end
+
+      def abstract?
+        true
+      end
+    end
+
+    def process(action_name, mailing)
+      @action_name = action_name
+      self.caffeinate_mailing = mailing
+      ::Caffeinate::ActionMailer::Interceptor.delivering_email(self)
+    end
+
+    def deliver
+      if self.perform_deliveries
+        send(@action_name, caffeinate_mailing)
+        ::Caffeinate::ActionMailer::Observer.delivered_email(self)
+      end
+    end
+  end
+end

--- a/lib/caffeinate/action.rb
+++ b/lib/caffeinate/action.rb
@@ -4,7 +4,7 @@ module Caffeinate
   # Allows you to use a PORO for a drip; acts just like ActionMailer::Base
   #
   # Usage:
-  #   class TextHandler < Caffeinate::Action
+  #   class TextAction < Caffeinate::Action
   #     def welcome(mailing)
   #       user = mailing.subscriber
   #       HTTParty.post("...") # ...
@@ -15,6 +15,27 @@ module Caffeinate
   #
   # Optionally, you can use the method for setup and return an object that implements `#deliver!`
   # and that will be invoked.
+  #
+  # usage:
+  #
+  #   class TextAction < Caffeinate::Action
+  #     class Envelope(user)
+  #       @sms = SMS.new(to: user.phone_number)
+  #     end
+  #
+  #     def deliver!(action)
+  #       # action will be the instantiated TextAction object
+  #       # and you can access action.action_name, etc.
+  #
+  #       erb = ERB.new(File.read(Rails.root + "app/views/cool_one_off_action/#{action_object.action_name}.text.erb"))
+  #       # ...
+  #       @sms.send!
+  #     end
+  #
+  #     def welcome(mailing)
+  #       Envelope.new(mailing.subscriber)
+  #     end
+  #   end
   class Action
     attr_accessor :caffeinate_mailing
     attr_accessor :perform_deliveries

--- a/lib/caffeinate/action_mailer/interceptor.rb
+++ b/lib/caffeinate/action_mailer/interceptor.rb
@@ -13,6 +13,10 @@ module Caffeinate
         drip = mailing.drip
         message.perform_deliveries = drip.enabled?(mailing)
       end
+
+      def self.delivering_message(message)
+        delivering_email(message)
+      end
     end
   end
 end

--- a/lib/caffeinate/action_mailer/interceptor.rb
+++ b/lib/caffeinate/action_mailer/interceptor.rb
@@ -13,10 +13,6 @@ module Caffeinate
         drip = mailing.drip
         message.perform_deliveries = drip.enabled?(mailing)
       end
-
-      def self.delivering_message(message)
-        delivering_email(message)
-      end
     end
   end
 end

--- a/lib/caffeinate/dripper/defaults.rb
+++ b/lib/caffeinate/dripper/defaults.rb
@@ -25,7 +25,7 @@ module Caffeinate
         # @option options [String] :mailer_class The mailer class
         def default(options = {})
           options.symbolize_keys!
-          options.assert_valid_keys(:mailer_class, :mailer, :using, :batch_size)
+          options.assert_valid_keys(:mailer_class, :mailer, :using, :batch_size, :action_class)
           @defaults = options
         end
       end

--- a/lib/caffeinate/dripper/drip_collection.rb
+++ b/lib/caffeinate/dripper/drip_collection.rb
@@ -4,7 +4,7 @@ module Caffeinate
   module Dripper
     # A collection of Drip objects for a `Caffeinate::Dripper`
     class DripCollection
-      VALID_DRIP_OPTIONS = [:mailer_class, :step, :delay, :every, :start, :using, :mailer, :at, :on].freeze
+      VALID_DRIP_OPTIONS = [:mailer_class, :action_class, :step, :delay, :every, :start, :using, :mailer, :at, :on].freeze
 
       include Enumerable
 
@@ -45,12 +45,12 @@ module Caffeinate
       def validate_drip_options(action, options)
         options.symbolize_keys!
         options.assert_valid_keys(*VALID_DRIP_OPTIONS)
-        options[:mailer_class] ||= options[:mailer] || @dripper.defaults[:mailer_class]
+        options[:mailer_class] ||= options[:action_class] || options[:mailer] || @dripper.defaults[:mailer_class]
         options[:using] ||= @dripper.defaults[:using]
         options[:step] ||= @dripper.drips.size + 1
 
         if options[:mailer_class].nil?
-          raise ArgumentError, "You must define :mailer_class or :mailer in the options for #{action.inspect} on #{@dripper.inspect}"
+          raise ArgumentError, "You must define :mailer_class, :mailer, or :action_class in the options for #{action.inspect} on #{@dripper.inspect}"
         end
 
         if options[:every].nil? && options[:delay].nil? && options[:on].nil?

--- a/lib/caffeinate/message_handler.rb
+++ b/lib/caffeinate/message_handler.rb
@@ -1,0 +1,20 @@
+module Caffeinate
+  # Delegates methods to a Caffeinate::Action class
+  class MessageHandler < Delegator
+    def initialize(action_class, action, message) # :nodoc:
+      @action_class, @action, @message = action_class, action, message
+    end
+
+    def __getobj__
+      processed_action
+    end
+
+    private
+
+    def processed_action
+      @processed_action ||= @action_class.new.tap do |action_object|
+        action_object.process @action, @message
+      end
+    end
+  end
+end

--- a/lib/caffeinate/version.rb
+++ b/lib/caffeinate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Caffeinate
-  VERSION = '2.2.0'
+  VERSION = '2.3.0'
 end

--- a/spec/caffeinate/action_spec.rb
+++ b/spec/caffeinate/action_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+describe Caffeinate::Action do
+  class CoolOneOffAction < Caffeinate::Action
+    def return_nil(mailing)
+
+    end
+
+    def return_mailing(mailing)
+      mailing
+    end
+
+    class ImplementsDelivery
+      def initialize
+
+      end
+
+      def deliver!(mailing)
+      end
+    end
+
+    def return_custom_thing(mailing)
+      ImplementsDelivery.new
+    end
+  end
+
+  let!(:campaign) { create(:caffeinate_campaign, :with_dripper) }
+  let(:subscription) { create(:caffeinate_campaign_subscription, caffeinate_campaign: campaign) }
+  let(:mailing) { subscription.mailings.first }
+
+  context '#process' do
+    subject do
+      instance = described_class.new
+      instance.process(:welcome, mailing)
+      instance
+    end
+
+    it 'sets the @action_name' do
+      expect(subject.instance_variable_get(:@action_name)).to eq(:welcome)
+    end
+
+    it 'sets the #caffeinate_mailing' do
+      expect(subject.caffeinate_mailing).to eq(mailing)
+    end
+  end
+
+  context '#deliver' do
+    subject do
+      CoolOneOffAction.return_nil(mailing).deliver
+    end
+
+    it 'informs interceptors' do
+      expect_any_instance_of(described_class).to receive(:inform_interceptors)
+      subject
+    end
+
+    it 'informs observers' do
+      expect_any_instance_of(described_class).to receive(:inform_observers)
+      subject
+    end
+
+    it 'calls do_delivery' do
+      expect_any_instance_of(described_class).to receive(:do_delivery)
+      subject
+    end
+  end
+
+  context 'when an action returns an object that responds to #deliver!' do
+
+    before do
+      campaign.to_dripper.drip :hello, mailer_class: 'ArgumentMailer', delay: 0.hours
+    end
+
+    let(:mailing) { subscription.caffeinate_mailings.first }
+    let(:subscription) { create(:caffeinate_campaign_subscription, caffeinate_campaign: campaign) }
+
+    it 'calls it' do
+      expect_any_instance_of(CoolOneOffAction::ImplementsDelivery).to receive(:deliver!)
+      CoolOneOffAction.return_custom_thing(mailing).deliver
+    end
+  end
+
+end

--- a/spec/caffeinate/action_spec.rb
+++ b/spec/caffeinate/action_spec.rb
@@ -79,5 +79,4 @@ describe Caffeinate::Action do
       CoolOneOffAction.return_custom_thing(mailing).deliver
     end
   end
-
 end

--- a/spec/caffeinate/action_spec.rb
+++ b/spec/caffeinate/action_spec.rb
@@ -103,4 +103,21 @@ describe Caffeinate::Action do
       expect { CoolOneOffAction.return_mailing(mailing).deliver }.to change(mailing, :sent_at)
     end
   end
+
+  context 'when an action returns an envelope that raises an error' do
+    subject do
+      allow_any_instance_of(CoolOneOffAction::Envelope).to receive(:deliver!).and_raise(StandardError)
+      CoolOneOffAction.return_custom_thing(mailing).deliver
+    end
+
+    it 'raises the error' do
+      expect { subject }.to raise_error(StandardError)
+    end
+
+    it 'does not change the mail' do
+
+
+      expect { subject rescue StandardError }.to_not change(mailing, :sent_at)
+    end
+  end
 end

--- a/spec/caffeinate/action_spec.rb
+++ b/spec/caffeinate/action_spec.rb
@@ -115,8 +115,6 @@ describe Caffeinate::Action do
     end
 
     it 'does not change the mail' do
-
-
       expect { subject rescue StandardError }.to_not change(mailing, :sent_at)
     end
   end

--- a/spec/caffeinate/drip_spec.rb
+++ b/spec/caffeinate/drip_spec.rb
@@ -98,6 +98,5 @@ describe Caffeinate::Drip do
     it 'uses the method' do
       expect(SomeFakeDripper.drip_collection.for(:action_name).send_at).to eq(2.years.from_now.beginning_of_year)
     end
-
   end
 end

--- a/spec/caffeinate/dripper/cases/drip_spec.rb
+++ b/spec/caffeinate/dripper/cases/drip_spec.rb
@@ -5,11 +5,12 @@ require 'rails_helper'
 describe ::Caffeinate::Dripper::Drip do
   class DripDripper < ::Caffeinate::Dripper::Base
     drip :test, delay: 0.hours, step: 1, mailer_class: 'CoolMailer'
+    drip :action_test, delay: 0.hours, step: 1, action_class: 'CoolAction'
   end
 
   describe '.drip' do
     it 'has a drips count' do
-      expect(DripDripper.drips.size).to eq(1)
+      expect(DripDripper.drips.size).to eq(2)
     end
 
     it 'registers a drip with valid arguments' do

--- a/spec/caffeinate/dripper/cases/perform_spec.rb
+++ b/spec/caffeinate/dripper/cases/perform_spec.rb
@@ -52,7 +52,18 @@ describe ::Caffeinate::Dripper::Perform do
 
   describe 'action classes' do
     class TestActionClass < Caffeinate::Action
+      class FakeDelivery
+        def initialize
+
+        end
+
+        def deliver!(thing)
+
+        end
+      end
+
       def welcome(mailing)
+        FakeDelivery.new
       end
     end
 

--- a/spec/caffeinate/dripper/cases/perform_spec.rb
+++ b/spec/caffeinate/dripper/cases/perform_spec.rb
@@ -49,4 +49,32 @@ describe ::Caffeinate::Dripper::Perform do
       expect(PerformDripper.upcoming_mailings.to_sql).to include(::Caffeinate::Mailing.table_name)
     end
   end
+
+  describe 'action classes' do
+    class TestActionClass < Caffeinate::Action
+      def welcome(mailing)
+      end
+    end
+
+    class PerformActionDripper < Caffeinate::Dripper::Base
+      self.campaign = :perform_action_dripper
+
+      drip :welcome, delay: -1.hour, action_class: "TestActionClass"
+    end
+
+    let!(:campaign) { create(:caffeinate_campaign, slug: 'perform_action_dripper') }
+    let(:campaign_subscription) { create(:caffeinate_campaign_subscription, caffeinate_campaign: campaign) }
+
+    it 'invokes the action' do
+      expect_any_instance_of(TestActionClass).to receive(:welcome).with(campaign_subscription.mailings.first).and_call_original
+      PerformActionDripper.perform!
+    end
+
+    it 'marks the mailing as sent' do
+      mailing = campaign_subscription.mailings.first
+      expect(mailing.sent_at).to be_nil
+      PerformActionDripper.perform!
+      expect(mailing.reload.sent_at).to be_present
+    end
+  end
 end


### PR DESCRIPTION
This will allow for PORO support, in addition to integrating with ActionMailer. 

In the future, we should rename `mailings` to `messages` and change the inference that Caffeinate only handles ActionMailer-based stuff to any-based stuff.

Resolves https://github.com/joshmn/caffeinate/issues/14

cc @jon-sully 