### PR TITLE
Only subscribe for active subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Important additions/changes/removals will appear here.
 
 ### Changed
 * A `Drip` now accepts an `action_class` option, in addition to the previous options
-* Calling `subscribe!` will now only `find_or_create` for active subscriptions
+* Calling `subscribe!` will now only `find_or_create` for active subscriptions (using `end!` will cause a subsequent `.subscribe` to yield a new/fresh subscription)
 
 ## v2.2.0 (March 20, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Important additions/changes/removals will appear here.
 
 
-## Master (April 20, 2023)
+## Master (April 22, 2023)
 
 ### Added 
 * RSpec matchers 
@@ -12,6 +12,7 @@ Important additions/changes/removals will appear here.
 
 ### Changed
 * A `Drip` now accepts an `action_class` option, in addition to the previous options
+* Calling `subscribe!` will now only `find_or_create` for active subscriptions
 
 ## v2.2.0 (March 20, 2023)
 

--- a/app/models/caffeinate/campaign.rb
+++ b/app/models/caffeinate/campaign.rb
@@ -74,13 +74,16 @@ module Caffeinate
 
     # Creates a `CampaignSubscription` object for the present Campaign. Allows passing `**args` to
     # delegate additional arguments to the record. Uses `find_or_create_by`.
+    #
+    # If a subscription hasn't ended, any existing subscription will be returned.
     def subscribe(subscriber, **args)
-      caffeinate_campaign_subscriptions.active.find_or_create_by(subscriber: subscriber, **args)
+      caffeinate_campaign_subscriptions.active.find_or_create_by(subscriber: subscriber, ended_at: nil, **args)
     end
 
     # Subscribes an object to a campaign. Raises `ActiveRecord::RecordInvalid` if the record was invalid.
+    # If a subscription hasn't ended, any existing subscription will be returned.
     def subscribe!(subscriber, **args)
-      caffeinate_campaign_subscriptions.active.find_or_create_by!(subscriber: subscriber, **args)
+      caffeinate_campaign_subscriptions.find_or_create_by!(subscriber: subscriber, ended_at: nil, **args)
     end
   end
 end

--- a/app/models/caffeinate/campaign.rb
+++ b/app/models/caffeinate/campaign.rb
@@ -75,12 +75,12 @@ module Caffeinate
     # Creates a `CampaignSubscription` object for the present Campaign. Allows passing `**args` to
     # delegate additional arguments to the record. Uses `find_or_create_by`.
     def subscribe(subscriber, **args)
-      caffeinate_campaign_subscriptions.find_or_create_by(subscriber: subscriber, **args)
+      caffeinate_campaign_subscriptions.active.find_or_create_by(subscriber: subscriber, **args)
     end
 
     # Subscribes an object to a campaign. Raises `ActiveRecord::RecordInvalid` if the record was invalid.
     def subscribe!(subscriber, **args)
-      caffeinate_campaign_subscriptions.find_or_create_by!(subscriber: subscriber, **args)
+      caffeinate_campaign_subscriptions.active.find_or_create_by!(subscriber: subscriber, **args)
     end
   end
 end

--- a/spec/models/caffeinate/campaign_subscription_spec.rb
+++ b/spec/models/caffeinate/campaign_subscription_spec.rb
@@ -170,4 +170,21 @@ describe Caffeinate::CampaignSubscription do
       }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
+
+  context 'multiple subscriptions' do
+    it 'creates a new active subscription' do
+      user = create(:user)
+      sub = campaign.subscribe!(user)
+      sub.end!
+      sub2 = campaign.subscribe!(user)
+      expect(sub2).to_not be(sub)
+    end
+
+    it 'returns the existing if there is an active sub' do
+      user = create(:user)
+      sub = campaign.subscribe!(user)
+      sub2 = campaign.subscribe!(user)
+      expect(sub2).to eq(sub)
+    end
+  end
 end

--- a/spec/models/caffeinate/campaign_subscription_spec.rb
+++ b/spec/models/caffeinate/campaign_subscription_spec.rb
@@ -177,7 +177,15 @@ describe Caffeinate::CampaignSubscription do
       sub = campaign.subscribe!(user)
       sub.end!
       sub2 = campaign.subscribe!(user)
-      expect(sub2).to_not be(sub)
+      expect(sub2).to_not eq(sub)
+    end
+
+    it 'returns an existing subscription if it is only unsubscribed' do
+      user = create(:user)
+      sub = campaign.subscribe!(user)
+      sub.unsubscribe!
+      sub2 = campaign.subscribe!(user)
+      expect(sub2).to eq(sub)
     end
 
     it 'returns the existing if there is an active sub' do


### PR DESCRIPTION
`Campaign#subscribe` should only `find_or_create` for subscriptions that haven't ended.