### PR TITLE
Campaign Subscription `:on_complete` after destruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Important additions/changes/removals will appear here.
 ### Changed
 * A `Drip` now accepts an `action_class` option, in addition to the previous options
 * Calling `subscribe!` will now only `find_or_create` for active subscriptions (using `end!` will cause a subsequent `.subscribe` to yield a new/fresh subscription)
+* If you destroy a `CampaignSubscription` it will no longer hit the `on_complete` callbacks ([#34](https://github.com/joshmn/caffeinate/pull/33))
 
 ## v2.2.0 (March 20, 2023)
 

--- a/app/models/caffeinate/campaign_subscription.rb
+++ b/app/models/caffeinate/campaign_subscription.rb
@@ -58,7 +58,7 @@ module Caffeinate
 
     after_create :create_mailings!
 
-    after_commit :on_complete, if: :completed?
+    after_commit :on_complete, if: :completed?, unless: :destroyed?
 
     # Add (new) drips to a `CampaignSubscriber`.
     #

--- a/spec/models/caffeinate/campaign_subscription_spec.rb
+++ b/spec/models/caffeinate/campaign_subscription_spec.rb
@@ -195,4 +195,13 @@ describe Caffeinate::CampaignSubscription do
       expect(sub2).to eq(sub)
     end
   end
+
+  describe 'on destroy' do
+    it 'does not run on_complete' do
+      allow(subscription).to receive(:completed?).and_return(true)
+      expect(subscription).to_not receive(:on_complete)
+      subscription.destroy!
+    end
+  end
+
 end


### PR DESCRIPTION
Submitting this little behavior change just to clarify that the `on_complete` callback shouldn't run during the destruction of a `campaign_subscription` (even if that's rare!). I think this happens because `:completed?` is technically true during destruction — the number of `unsent` mailings is indeed zero, because they're all deleted first 😛 