### PR TITLE
CampaignSubscription `#end!` when already ended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Important additions/changes/removals will appear here.
 * Calling `subscribe!` will now only `find_or_create` for active subscriptions (using `end!` will cause a subsequent `.subscribe` to yield a new/fresh subscription)
 * If you destroy a `CampaignSubscription` it will no longer hit the `on_complete` callbacks ([#34](https://github.com/joshmn/caffeinate/pull/33))
 
+### Fixed 
+* Calling `end!` in a callback won't end up in an infinite loop. ([#35](https://github.com/joshmn/caffeinate/pull/35))
+
 ## v2.2.0 (March 20, 2023)
 
 ### Fixed

--- a/app/models/caffeinate/campaign_subscription.rb
+++ b/app/models/caffeinate/campaign_subscription.rb
@@ -99,7 +99,7 @@ module Caffeinate
     # Updates `ended_at` and runs `on_complete` callbacks
     def end!(reason = ::Caffeinate.config.default_ended_reason)
       raise ::Caffeinate::InvalidState, 'CampaignSubscription is already unsubscribed.' if unsubscribed?
-      return true if !!ended_at
+      return true if ended?
 
       update!(ended_at: ::Caffeinate.config.time_now, ended_reason: reason)
 

--- a/app/models/caffeinate/campaign_subscription.rb
+++ b/app/models/caffeinate/campaign_subscription.rb
@@ -110,6 +110,7 @@ module Caffeinate
     # Updates `ended_at` and runs `on_complete` callbacks
     def end(reason = ::Caffeinate.config.default_ended_reason)
       return false if unsubscribed?
+      return true if ended?
 
       result = update(ended_at: ::Caffeinate.config.time_now, ended_reason: reason)
 

--- a/app/models/caffeinate/campaign_subscription.rb
+++ b/app/models/caffeinate/campaign_subscription.rb
@@ -99,6 +99,7 @@ module Caffeinate
     # Updates `ended_at` and runs `on_complete` callbacks
     def end!(reason = ::Caffeinate.config.default_ended_reason)
       raise ::Caffeinate::InvalidState, 'CampaignSubscription is already unsubscribed.' if unsubscribed?
+      return true if !!ended_at
 
       update!(ended_at: ::Caffeinate.config.time_now, ended_reason: reason)
 

--- a/spec/models/caffeinate/campaign_subscription_spec.rb
+++ b/spec/models/caffeinate/campaign_subscription_spec.rb
@@ -34,6 +34,14 @@ describe Caffeinate::CampaignSubscription do
   end
 
   describe '#end!' do
+    context 'when already ended' do
+      it 'no-ops on subsequent #end! calls' do
+        expect(subscription).to receive(:update!)
+        subscription.end!
+        expect(subscription).to_not receive(:update!)
+        subscription.end!
+      end
+    end
     context 'without argument' do
       it 'is not ended' do
         expect(subscription).not_to be_ended

--- a/spec/models/caffeinate/campaign_subscription_spec.rb
+++ b/spec/models/caffeinate/campaign_subscription_spec.rb
@@ -36,10 +36,11 @@ describe Caffeinate::CampaignSubscription do
   describe '#end!' do
     context 'when already ended' do
       it 'no-ops on subsequent #end! calls' do
-        expect(subscription).to receive(:update!)
         subscription.end!
+        first_ended_at = subscription.ended_at
         expect(subscription).to_not receive(:update!)
         subscription.end!
+        expect(first_ended_at).to eq subscription.ended_at
       end
     end
     context 'without argument' do


### PR DESCRIPTION
Ran into a little infinite loop when calling `cs.end!` from inside an `on_complete` block:

```ruby
  on_complete do |campaign_subscription|
    # Marking ended instead of just letting it be complete so subscriber
    # can be subscribed again in the future
    campaign_subscription.end!
  end
```

Since calling `.end!` calls `.update!` inside of it, which will then trigger the `after_commit` and thus back into the `on_complete` block ^ and the cycle executes again ad infinitum!

I figured this was a graceful way to avoid the `after_commit` callback if the thing is already ended! WDYT?