### PR TITLE
Fix improper use of bang method in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ a `Caffeinate::CampaignSubscription`.
 ```ruby
 class User < ApplicationRecord
   after_commit on: :create do
-    OnboardingDripper.subscribe!(self)
+    OnboardingDripper.subscribe(self)
   end
 end
 ```


### PR DESCRIPTION
`subscribe!` bang method is not an available on `OnboardingDripper` directly. Instead, would need to use 
```
OnboardingDripper.campaign.subscribe!
```